### PR TITLE
[#1] Train/Pack/Deploy templates as a single Argo WorkflowTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # ODAHU Argo Templates
 ODAHU extensions for Argo https://github.com/argoproj/ 
 
+Table of Content:
+1. [Install](#install)
+2. [Templates](#templates)
+3. [Examples](#examples)
+
 ## Install
 
 As any Argo `WorkflowTemplate` ODAHU's set of templates can be installed via Argo CLI or Kubernetes CLI:
@@ -30,6 +35,63 @@ data:
 ```
 
 A reference to this k8s Secret must be provided to any ODAHU step in `odahuCredentialsSecret` parameter, or it will default to secret named `odahu-credentials` in the same namespace where Workflow runs.
+
+## Templates
+
+Common inputs of all templates:
+|           Input          |  Type  | Mandatory |       Default       |                                                                                                        Description                                                                                                        |
+|:------------------------:|:------:|:---------:|:-------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+|        `odahuURL`        | string |  **yes**  |                     |                                                                                                   Base URL of ODAHU API                                                                                                   |
+| `odahuCredentialsSecret` | string |     no    | `odahu-credentials` | Reference to K8s Secret with [ODAHU Credentials](#odahu-credentials); <br>Possible formats:<br>- `odahu-credentials`<br>- `/api/v1/secrets/odahu-credentials`<br>- `/api/v1/namespaces/some-ns/secrets/odahu-credentials` |
+|     `wait_completion`    | string |     no    |       `"true"`      |                 Possible values: `"true"`/`"false"`.<br>When `"true"` the step will wait for operation to successfully complete. <br>When `"false"`, the step will succeed right after request submission.                |
+
+### Model Training Template
+
+Training template creates a new `ModelTraining` object in ODAHU cluster.
+
+Inputs:
+| Input            | Type     | Mandatory | Default | Description                                                         |
+|------------------|----------|-----------|---------|---------------------------------------------------------------------|
+| trainingManifest | artifact | **yes**   |         | [YAML Training Manifest](https://docs.odahu.org/ref_trainings.html) |
+
+Outputs:
+| Output      | Type   | Description                   |
+|-------------|--------|-------------------------------|
+| training_id | string | ID of created `ModelTraining` |
+
+### Model Packaging Template
+
+Packaging template creates a new `ModelPackaging` object in ODAHU cluster.
+
+For convenient steps pipelining Packaging template supports `fromTrainingID`. Read more in Inputs table below.
+
+Inputs:
+| Input             | Type     | Mandatory | Default | Description                                                          |
+|-------------------|----------|-----------|---------|----------------------------------------------------------------------|
+| packagingManifest | artifact | **yes**   |         | [YAML Packaging Manifest](https://docs.odahu.org/ref_packagers.html) |
+| fromTrainingID    | string   | no        |         | `fromTrainingID` points to a training that produced a model artifact. If specified "artifactName" field will be overridden by the last artifact of referenced Training |
+
+Outputs:
+| Output       | Type   | Description                    |
+|--------------|--------|--------------------------------|
+| packaging_id | string | ID of created `ModelPackaging` |
+
+### Model Deployment Template
+
+Deployment template creates a new `ModelDeployment` object in ODAHU cluster.
+
+For convenient steps pipelining Deployment template supports `fromPackagingID`. Read more in Inputs table below.
+
+Inputs:
+| Input              | Type     | Mandatory | Default | Description                                                             |
+|--------------------|----------|-----------|---------|-------------------------------------------------------------------------|
+| deploymentManifest | artifact | **yes**   |         | [YAML Deployment Manifest](https://docs.odahu.org/ref_deployments.html) |
+| fromPackagingID    | string   | no        |         | `fromPackagingID` points to a packaging that produced a model image. If specified "image" field will be overridden by the result image from referenced Packaging |
+
+Outputs:
+| Output        | Type   | Description                     |
+|---------------|--------|---------------------------------|
+| deployment_id | string | ID of created `ModelDeployment` |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# odahu-argo
+# ODAHU Argo Templates
 ODAHU extensions for Argo https://github.com/argoproj/ 
+
+## Install
+
+As any Argo `WorkflowTemplate` ODAHU's set of templates can be installed via Argo CLI or Kubernetes CLI:
+```shell
+argo template create ./odahu.templates.yaml
+```
+OR 
+```shell
+kubectl apply -f ./odahu.templates.yaml
+```
+
+### ODAHU Credentials
+To access ODAHU API any of Argo ODAHU templates require a secret with the following structure:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: odahu-credentials
+data:
+  client_id: <b64_client_id>
+  client_secret: <b64_client_secret>
+  issuer_url: <b64_issuer_url>
+```
+
+By default ODAHU steps will look for secret named `odahu-credentials`, but it can be customized by 
+`odahuCredentialsSecret` parameter.
+
+## Examples
+
+1. [Model Train-Pack-Deploy pipeline with building dynamic Training manifest 
+   in a separate Python step](examples/python-manifest-generation.workflow.yaml)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ Outputs:
 | deployment_id | string | ID of created `ModelDeployment` |
 
 ## Examples
-
+1. [Model Training paramterized by input parameters](examples/parametrized-training.workflow.yaml)
 1. [Model Train-Pack-Deploy pipeline with building dynamic Training manifest 
    in a separate Python step](examples/python-manifest-generation.workflow.yaml)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ kubectl apply -f ./odahu.templates.yaml
 ```
 
 ### ODAHU Credentials
-To access ODAHU API any of Argo ODAHU templates require a secret with the following structure:
+As any ODAHU API clients, Argo tasks must pass through regular authentication procedure with Identity Provider (such as Keycloak). 
+Find more in [Security section](https://docs.odahu.org/gen_security.html) of ODAHU documentation.
+
+It is recommended to create a separate Service Account in Identity Provider for Argo Workflows with minimal required permissions. 
+Credentials for the Service Account have to be put to k8s cluster as a secret with the following structure:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -25,8 +29,7 @@ data:
   issuer_url: <b64_issuer_url>
 ```
 
-By default ODAHU steps will look for secret named `odahu-credentials`, but it can be customized by 
-`odahuCredentialsSecret` parameter.
+A reference to this k8s Secret must be provided to any ODAHU step in `odahuCredentialsSecret` parameter, or it will default to secret named `odahu-credentials` in the same namespace where Workflow runs.
 
 ## Examples
 

--- a/examples/parametrized-training.workflow.yaml
+++ b/examples/parametrized-training.workflow.yaml
@@ -1,0 +1,70 @@
+# This example runs model training in ODAHU. It demonstrates how user can define a training manifest with
+# placeholders which will be replaced with real values provided in Workflow parameters.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: wine-argo-
+spec:
+  entrypoint: training-steps
+
+  podGC:
+    strategy: OnWorkflowSuccess
+
+  # This example workflow accepts 3 parameters which are passed to downstream steps or
+  # rendered in template strings. You can define any parameters
+  arguments:
+    parameters:
+      # odahuURL is a mandatory parameter and must be explicitly provided on workflow submission
+      # The parameter is passed to downstream ODAHU steps
+      - name: odahuURL
+        value:
+      # hyperParametersJSON is a mapping (JSON Object) with values of hyper-parameters for training
+      - name: hyperParametersJSON
+        value: '{"alpha": "1.0"}'
+      # dataBucketPath is a path to training data in bucket
+      # It may be useful if new versions of dataset are put to different locations in the same bucket
+      - name: dataBucketPath
+        value: /data/wine-quality.csv
+
+  templates:
+    - name: training-steps
+      steps:
+        # Call to predefined training template from ODAHU WorkflowTemplate
+        - - name: train
+            templateRef:
+              name: odahu
+              template: training
+            # Passing required arguments to training template:
+            # - odahuURL from workflow input arguments
+            # - trainingManifest artifact produced by previous step
+            arguments:
+              parameters:
+                - name: odahuURL
+                  value: "{{ workflow.parameters.odahuURL }}"
+              artifacts:
+                # Notice: an input manifest can be provided as a static inline data
+                - name: trainingManifest
+                  raw:
+                    data: |
+                      kind: ModelTraining
+                      id: {{ workflow.name }}
+                      spec:
+                        model:
+                          name: wine
+                          version: 1.0
+                        toolchain: mlflow
+                        entrypoint: main
+                        workDir: mlflow/sklearn/wine
+                        data:
+                          - connName: models-output
+                            remotePath: {{ workflow.parameters.dataBucketPath }}
+                            localPath: mlflow/sklearn/wine/wine-quality.csv
+                        hyperParameters: {{ workflow.parameters.hyperParametersJSON }}
+                        resources:
+                          limits:
+                            cpu: 4
+                            memory: 4Gi
+                          requests:
+                            cpu: 2
+                            memory: 2Gi
+                        vcsName: odahu-flow-examples

--- a/examples/python-manifest-generation.workflow.yaml
+++ b/examples/python-manifest-generation.workflow.yaml
@@ -1,0 +1,199 @@
+# This example runs train-pack-deploy pipeline in ODAHU. It demonstrates the way to dynamically generate Training
+# manifest via arbitrary Python logic and ODAHU Python SDK. This allows to calculate some dynamic values in runtime
+# or fetch them from any side-services.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: wine-argo-
+spec:
+  entrypoint: full-pipeline
+
+  podGC:
+    strategy: OnWorkflowSuccess
+
+  # This example workflow accepts 3 parameters
+  arguments:
+    parameters:
+      # odahuURL is a mandatory parameter and must be explicitly provided on workflow submission
+      # The parameter is passed to downstream ODAHU steps
+      - name: odahuURL
+        value:
+      # algorithmVcsRef is a git reference to ML algorithm source code
+      # User may want to modify this to switch a release tag or to test something from feature-branch
+      # Defaults to develop
+      - name: algorithmVcsRef
+        value: develop
+      # dataBucketPath is a path to training data in bucket
+      # It may be useful if new versions of dataset are put to different locations in the same bucket
+      - name: dataBucketPath
+        value: /data/wine-quality.csv
+
+  templates:
+    - name: full-pipeline
+      steps:
+        # Call to user-defined template (see bottom of the file) to generate training manifest
+        - - name: generate-training-manifest
+            template: generate-training-manifest
+            arguments:
+              parameters:
+                - name: bucketPath
+                  value: "{{ workflow.parameters.dataBucketPath }}"
+                - name: vcsRef
+                  value: "{{ workflow.parameters.algorithmVcsRef }}"
+                  
+        # Call to predefined training template from ODAHU WorkflowTemplate 
+        - - name: train
+            templateRef:
+              name: odahu
+              template: training
+            # Passing required arguments to training template:
+            # - odahuURL from workflow input arguments
+            # - trainingManifest artifact produced by previous step
+            arguments:
+              parameters:
+                - name: odahuURL
+                  value: "{{ workflow.parameters.odahuURL }}"
+              artifacts:
+                - name: trainingManifest
+                  from: "{{steps.generate-training-manifest.outputs.artifacts.trainingManifest}}"
+
+        # Call to predefined packaging template from ODAHU WorkflowTemplate
+        - - name: pack
+            templateRef:
+              name: odahu
+              template: packaging
+            arguments:
+              parameters:
+                - name: odahuURL
+                  value: "{{ workflow.parameters.odahuURL }}"
+                # fromTrainingID points to a training that produced a model artifact
+                # if specified "artifactName" field will be overridden by the last artifact of referenced Training
+                - name: fromTrainingID
+                  value: "{{steps.train.outputs.parameters.training_id}}"
+              artifacts:
+                # Notice: an input manifest can be provided as a static inline data
+                - name: packagingManifest
+                  raw:
+                    data: |
+                      id: {{ workflow.name }}
+                      kind: ModelPackaging
+                      spec:
+                        artifactName: "will be overridden because of fromTrainingID"
+                        integrationName: docker-rest
+                        resources:
+                          limits:
+                            cpu: "1.5"
+                            memory: 4Gi
+                          requests:
+                            cpu: "1.5"
+                            memory: 2Gi
+
+        # Call to predefined deployment template from ODAHU WorkflowTemplate
+        - - name: deploy
+            templateRef:
+              name: odahu
+              template: deployment
+            arguments:
+              parameters:
+                - name: odahuURL
+                  value: "{{ workflow.parameters.odahuURL }}"
+                # fromPackagingID points to a packaging that produced a model image
+                # if specified "image" field will be overridden by the result image from referenced Packaging
+                - name: fromPackagingID
+                  value: "{{steps.pack.outputs.parameters.packaging_id}}"
+              artifacts:
+                - name: deploymentManifest
+                  raw:
+                    data: |
+                      id: {{ workflow.name }}
+                      kind: ModelDeployment
+                      spec:
+                        image: "will be overridden because of fromPackagingID"
+                        predictor: odahu-ml-server
+                        minReplicas: 0
+                        maxReplicas: 1
+
+    # Example template that builds training manifest from static Python configuration and 
+    # provided input parameters
+    - name: generate-training-manifest
+      inputs:
+        parameters:
+          - name: bucketPath
+          - name: vcsRef
+      outputs:
+        artifacts:
+          - name: trainingManifest
+            path: /tmp/train.yaml
+      script:
+        image: odahu/odahu-flow-cli:1.5.0-rc4
+        command: [ "python" ]
+        source: |
+          import yaml
+          from odahuflow.sdk.models.model_training import ModelTraining
+          from odahuflow.sdk.models.model_training_spec import ModelTrainingSpec
+          from odahuflow.sdk.models.model_identity import ModelIdentity
+          from odahuflow.sdk.models.resource_requirements import ResourceRequirements
+          from odahuflow.sdk.models.resource_list import ResourceList
+          from odahuflow.sdk.models.data_binding_dir import DataBindingDir
+
+
+          model=ModelIdentity(
+              name='wine-mlflow',
+              version='{{ inputs.parameters.vcsRef }}',
+              artifact_name_template='{{ .Name }}-{{ .Version }}-{{ .RandomUUID }}.zip'
+          )
+
+          input_data_binding = DataBindingDir(
+              conn_name='models-output',
+              local_path='mlflow/sklearn/wine/',
+              remote_path='{{ inputs.parameters.bucketPath }}'
+          )
+
+          resource_request = ResourceList(
+              cpu='2000m',
+              memory='2024Mi',
+          )
+          resource_limit = ResourceList(
+              cpu='4000m',
+              memory='4024Mi',
+          )
+          training_resources = ResourceRequirements(
+              requests=resource_request,
+              limits=resource_limit,
+          )
+
+          train = ModelTraining(
+              id='{{ workflow.name }}',
+              spec=ModelTrainingSpec(
+                  model=model,
+                  toolchain='mlflow',
+
+                  hyper_parameters={'alpha': '1.0'},
+                  work_dir='mlflow/sklearn/wine',
+                  entrypoint='main',
+
+                  vcs_name='odahu-flow-examples',
+                  reference='{{ inputs.parameters.vcsRef }}',
+
+                  data=[input_data_binding],
+
+                  output_connection='models-output',
+
+                  resources=training_resources,
+              )
+          )
+
+          print('Converting ModelTraining to dict...')
+
+          train_dict = train.to_dict()
+          # This is required for historical reasons and will be fixed soon
+          train_dict['kind'] = 'ModelTraining'
+          print(train_dict)
+
+          print('Dumping to yaml...')
+          train_yaml = yaml.safe_dump(train_dict)
+          print(train_yaml)
+
+          print('Saving to file...')
+          with open('/tmp/train.yaml', 'w') as f:
+              f.write(train_yaml)

--- a/odahu.templates.yaml
+++ b/odahu.templates.yaml
@@ -1,0 +1,245 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: odahu
+spec:
+  templates:
+    - name: training
+      inputs:
+        parameters:
+          - name: odahuURL
+          - name: odahuCredentialsSecret
+            default: odahu-credentials
+          - name: wait_completion
+            default: "true"
+        artifacts:
+          - name: trainingManifest
+            path: /odahu/training.yaml
+      outputs:
+        parameters:
+          - name: training_id
+            valueFrom:
+              path: /odahu/training_id.txt
+
+      script:
+        image: odahu/odahu-flow-cli:1.5.0-rc4
+        envFrom:
+          - secretRef:
+              name: odahu-credentials
+        command: ["python"]
+        source: |
+          import os
+          import sys
+          import time
+          from odahuflow.sdk.clients.api_aggregated import parse_resources_file_with_one_item
+          from odahuflow.sdk.clients.training import ModelTrainingClient, TRAINING_SUCCESS_STATE, TRAINING_FAILED_STATE
+
+          str_to_bool = {'true': True, 'false': False}
+
+          wait_completion_str = '{{inputs.parameters.wait_completion}}'
+          if wait_completion_str not in str_to_bool:
+              raise ValueError(f'wait_completion must be one of {list(str_to_bool.keys())}')
+          wait_completion = str_to_bool[wait_completion_str]
+
+          training_manifest_path = '/odahu/training.yaml'
+          manifest = parse_resources_file_with_one_item(training_manifest_path)
+          train_id = manifest.resource_id
+          train = manifest.resource
+
+          print('Found resource:')
+          print(train)
+
+          client = ModelTrainingClient(
+              base_url='{{inputs.parameters.odahuURL}}',
+              client_id=os.getenv('client_id'),
+              client_secret=os.getenv('client_secret'),
+              issuer_url=os.getenv('issuer_url')
+          )
+
+          created_mt = client.create(train)
+          with open('/odahu/training_id.txt', 'w') as f:
+              f.write(created_mt.id)
+
+          if not wait_completion:
+              sys.exit(0)
+
+          while True:
+              running_mt = client.get(created_mt.id)
+              if running_mt.status.state in [TRAINING_SUCCESS_STATE, TRAINING_FAILED_STATE]:
+                  break
+              time.sleep(5)
+
+          if running_mt.status.state != TRAINING_SUCCESS_STATE:
+              raise Exception(f'Expected Model Training {running_mt.id} to be in {TRAINING_SUCCESS_STATE} state')
+
+    - name: packaging
+      inputs:
+        parameters:
+          - name: odahuURL
+          - name: odahuCredentialsSecret
+            default: /api/v1/secrets/odahu-credentials
+          - name: wait_completion
+            default: "true"
+          - name: fromTrainingID
+            default:
+        artifacts:
+          - name: packagingManifest
+            path: /odahu/packaging.yaml
+      outputs:
+        parameters:
+          - name: packaging_id
+            valueFrom:
+              path: /odahu/packaging_id.txt
+      script:
+        image: odahu/odahu-flow-cli:1.5.0-rc4
+        envFrom:
+          - secretRef:
+              name: odahu-credentials
+        command: [ "python" ]
+        source: |
+          import os
+          import sys
+          import time
+          from odahuflow.sdk.clients.api_aggregated import parse_resources_file_with_one_item
+          from odahuflow.sdk.clients.packaging import ModelPackagingClient, SUCCEEDED_STATE, FAILED_STATE
+          from odahuflow.sdk.clients.training import ModelTrainingClient
+
+          str_to_bool = {'true': True, 'false': False}
+
+          wait_completion_str = '{{inputs.parameters.wait_completion}}'
+          if wait_completion_str not in str_to_bool:
+              raise ValueError(f'wait_completion must be one of {list(str_to_bool.keys())}')
+          wait_completion = str_to_bool[wait_completion_str]
+
+          packaging_manifest_path = '/odahu/packaging.yaml'
+          manifest = parse_resources_file_with_one_item(packaging_manifest_path)
+          packaging_id = manifest.resource_id
+          packaging = manifest.resource
+
+          print('Found resource:')
+          print(packaging)
+
+          fromTrainingID = '{{inputs.parameters.fromTrainingID}}'
+          if fromTrainingID:
+              print(f'Fetching artifact name from Model Training {fromTrainingID}')
+              mt_client = ModelTrainingClient(
+                  base_url='{{inputs.parameters.odahuURL}}',
+                  client_id=os.getenv('client_id'),
+                  client_secret=os.getenv('client_secret'),
+                  issuer_url=os.getenv('issuer_url')
+              )
+              mt = mt_client.get(fromTrainingID)
+              packaging.spec.artifact_name = mt.status.artifacts[-1].artifact_name
+              print(f'New articaft name: {packaging.spec.artifact_name}')
+
+          client = ModelPackagingClient(
+              base_url='{{inputs.parameters.odahuURL}}',
+              client_id=os.getenv('client_id'),
+              client_secret=os.getenv('client_secret'),
+              issuer_url=os.getenv('issuer_url')
+          )
+
+          created_mp = client.create(packaging)
+          with open('/odahu/packaging_id.txt', 'w') as f:
+              f.write(created_mp.id)
+
+          if not wait_completion:
+              sys.exit(0)
+
+          while True:
+              running_mp = client.get(created_mp.id)
+              if running_mp.status.state in [SUCCEEDED_STATE, FAILED_STATE]:
+                  break
+              time.sleep(5)
+
+          if running_mp.status.state != SUCCEEDED_STATE:
+              raise Exception(f'Expected Model Packaging {running_mp.id} to be in {SUCCEEDED_STATE} state')
+
+    - name: deployment
+      inputs:
+        parameters:
+          - name: odahuURL
+          - name: odahuCredentialsSecret
+            default: /api/v1/secrets/odahu-credentials
+          - name: wait_completion
+            default: "true"
+          - name: fromPackagingID
+            default:
+        artifacts:
+          - name: deploymentManifest
+            path: /odahu/deployment.yaml
+      outputs:
+        parameters:
+          - name: deployment_id
+            valueFrom:
+              path: /odahu/deployment_id.txt
+      script:
+        image: odahu/odahu-flow-cli:1.5.0-rc4
+        envFrom:
+          - secretRef:
+              name: odahu-credentials
+        command: [ "python" ]
+        source: |
+          import os
+          import sys
+          import time
+          from odahuflow.sdk.clients.api_aggregated import parse_resources_file_with_one_item
+          from odahuflow.sdk.clients.deployment import ModelDeploymentClient, READY_STATE, FAILED_STATE
+          from odahuflow.sdk.clients.packaging import ModelPackagingClient
+
+          str_to_bool = {'true': True, 'false': False}
+
+          wait_completion_str = '{{inputs.parameters.wait_completion}}'
+          if wait_completion_str not in str_to_bool:
+              raise ValueError(f'wait_completion must be one of {list(str_to_bool.keys())}')
+          wait_completion = str_to_bool[wait_completion_str]
+
+          deployment_manifest_path = '/odahu/deployment.yaml'
+          manifest = parse_resources_file_with_one_item(deployment_manifest_path)
+          deployment_id = manifest.resource_id
+          deployment = manifest.resource
+
+          print('Found resource:')
+          print(deployment)
+
+          fromPackagingID = '{{inputs.parameters.fromPackagingID}}'
+          if fromPackagingID:
+              print(f'Fetching image name from Model Packaging {fromPackagingID}')
+              mp_client = ModelPackagingClient(
+                  base_url='{{inputs.parameters.odahuURL}}',
+                  client_id=os.getenv('client_id'),
+                  client_secret=os.getenv('client_secret'),
+                  issuer_url=os.getenv('issuer_url')
+              )
+              mp = mp_client.get(fromPackagingID)
+
+              for result in mp.status.results:
+                  if result.name == 'image':
+                      deployment.spec.image = result.value
+                      print(f'Image fetched from packaging: {deployment.spec.image}')
+                      break
+
+          client = ModelDeploymentClient(
+              base_url='{{inputs.parameters.odahuURL}}',
+              client_id=os.getenv('client_id'),
+              client_secret=os.getenv('client_secret'),
+              issuer_url=os.getenv('issuer_url')
+          )
+
+          created_md = client.create(deployment)
+          with open('/odahu/deployment_id.txt', 'w') as f:
+              f.write(created_md.id)
+
+          if not wait_completion:
+              sys.exit(0)
+
+          while True:
+              print('cheking status')
+              running_md = client.get(created_md.id)
+              print(f'"{running_md.status.state}", "{READY_STATE}", "{FAILED_STATE}"')
+              if running_md.status.state in [READY_STATE, FAILED_STATE]:
+                  break
+              time.sleep(5)
+
+          if running_md.status.state != READY_STATE:
+              raise Exception(f'Expected Model Deployment {running_md.id} to be in {READY_STATE} state')


### PR DESCRIPTION
3 Argo templates are added in a single `WorkflowTemplate` manifest:
- `training`
- `packaging`
- `deployment`

All 3 templates expect a corresponding YAML-manifest as an input artifact. 
They also have parameters:
- `odahuURL`: ODAHU API base URL
- `waitCompletion`: if true, a step succeeds if only train/pack/deploy completes successfully. Otherwise it succeeds on entity submission without waiting for result.
- `odahuCredentialsSecret`: name of k8s secret in the same namespace of the following content:
```
apiVersion: v1
kind: Secret
metadata:
  name: odahu-credentials
data:
  client_id: <b64_client_id>
  client_secret: <b64_client_secret>
  issuer_url: <b64_issuer_url>
```
`packagin` and `deployment` also support parameters `fromTrainingID`/`fromPackagingID` correspondingly. 
- `fromTrainingID` overrides the `artifactName` in packaging manifest with the last artifact of specified training
- `fromPackagingID` overrides the `image` in deployment manifest with the result image of specified packaging