### PR TITLE
Parametrize odahu version in Argo templates

### DIFF
--- a/odahu.templates.yaml
+++ b/odahu.templates.yaml
@@ -8,6 +8,8 @@ spec:
       inputs:
         parameters:
           - name: odahuURL
+          - name: docker_tag
+            default: latest
           - name: odahuCredentialsSecret
             default: odahu-credentials
           - name: wait_completion
@@ -22,7 +24,7 @@ spec:
               path: /odahu/training_id.txt
 
       script:
-        image: odahu/odahu-flow-cli:1.5.0-rc4
+        image: odahu/odahu-flow-cli:{{inputs.parameters.docker_tag}}
         envFrom:
           - secretRef:
               name: odahu-credentials
@@ -76,6 +78,8 @@ spec:
       inputs:
         parameters:
           - name: odahuURL
+          - name: docker_tag
+            default: latest
           - name: odahuCredentialsSecret
             default: /api/v1/secrets/odahu-credentials
           - name: wait_completion
@@ -91,7 +95,7 @@ spec:
             valueFrom:
               path: /odahu/packaging_id.txt
       script:
-        image: odahu/odahu-flow-cli:1.5.0-rc4
+        image: odahu/odahu-flow-cli:{{inputs.parameters.docker_tag}}
         envFrom:
           - secretRef:
               name: odahu-credentials
@@ -159,6 +163,8 @@ spec:
       inputs:
         parameters:
           - name: odahuURL
+          - name: docker_tag
+            default: latest
           - name: odahuCredentialsSecret
             default: /api/v1/secrets/odahu-credentials
           - name: wait_completion
@@ -174,7 +180,7 @@ spec:
             valueFrom:
               path: /odahu/deployment_id.txt
       script:
-        image: odahu/odahu-flow-cli:1.5.0-rc4
+        image: odahu/odahu-flow-cli:{{inputs.parameters.docker_tag}}
         envFrom:
           - secretRef:
               name: odahu-credentials


### PR DESCRIPTION
Image tag that is used in ODAHU Argo templates was hardcoded and fixed to 1.5.0. 
Now it is parametrized and user must provide appropriate odahu version. 